### PR TITLE
Don't show usage (and duplicate error) for `skate get` no-such-key errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,11 +39,13 @@ var (
 	}
 
 	getCmd = &cobra.Command{
-		Use:    "get KEY[@DB]",
-		Hidden: false,
-		Short:  "Get a value for a key with an optional @ db.",
-		Args:   cobra.ExactArgs(1),
-		RunE:   get,
+		Use:           "get KEY[@DB]",
+		Hidden:        false,
+		Short:         "Get a value for a key with an optional @ db.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE:          get,
 	}
 
 	deleteCmd = &cobra.Command{


### PR DESCRIPTION
Currently, if you run `skate get` against a key that doesn't exist it returns the following output:

```
Error: Key not found
Usage:
   get KEY[@DB] [flags]

Flags:
  -h, --help   help for get

Key not found
```

Because the syntax of the command is correct and the given key simply doesn't exist, this PR removes the usage info (and duplicate error message), resulting in the following:

```
Key not found
```