### PR TITLE
Show help if run with no args

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 		Short:  "Skate, a personal key value store.",
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			return cmd.Help()
 		},
 	}
 


### PR DESCRIPTION
If `skate` runs with no args it simply exits silently. This PR prints the help if `skate` is run with no arguments.