### PR TITLE
docs: Fix charm/kv link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ local network. For details, see the [Charm docs][selfhost].
 
 ## Hey, Developers
 
-Skate is built on [charm/kv](https://github.com/charmbracelet/charm/kv). If
+Skate is built on [charm/kv](https://github.com/charmbracelet/charm#charm-kv). If
 you’d like to build a tool that includes a user key value store, check it out.
 
 ## License


### PR DESCRIPTION
Hi, just a little PR to fix a broken link to charm/kv in the README :)