### PR TITLE
feat: add command to list databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ skate set "office rumor"@work-stuff "penelope likes marmalade"
 skate get "office rumor"@work-stuff
 skate list @work-stuff
 
+# Wait, what was that db named?
+skate list-dbs
+
 # Oh no, the boss is coming!
 skate reset @work-stuff
 ```

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ var (
 		Use:    "list-dbs",
 		Hidden: false,
 		Short:  "List databases.",
-		Args:   cobra.MaximumNArgs(0),
+		Args:   cobra.NoArgs,
 		RunE:   listDbs,
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
@@ -148,6 +149,17 @@ func list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	db.Sync()
+	if len(args) == 0 {
+		pn := filepath.Join(os.Getenv("CHARMPATH"), db.Client().Config.Host, "/kv/")
+		dbs, err := os.ReadDir(pn)
+		if err != nil {
+			return err
+		}
+		for _, d := range dbs {
+			fmt.Println("@" + d.Name())
+		}
+		return nil
+	}
 	return db.View(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
 		opts.PrefetchSize = 10

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
@@ -143,8 +142,11 @@ func listDbs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	db.Sync()
-  pn := filepath.Join(os.Getenv("CHARMPATH"), db.Client().Config.Host, "/kv/")
-  dbs, err := os.ReadDir(pn)
+  pn, err := db.Client().DataPath()
+  if err != nil {
+    return err
+  }
+  dbs, err := os.ReadDir(pn + "/kv/")
   if err != nil {
     return err
   }

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
+	"github.com/charmbracelet/charm/client"
 	"github.com/charmbracelet/charm/cmd"
 	"github.com/charmbracelet/charm/kv"
 	"github.com/charmbracelet/charm/ui/common"
@@ -137,23 +139,22 @@ func delete(cmd *cobra.Command, args []string) error {
 }
 
 func listDbs(cmd *cobra.Command, args []string) error {
-	db, err := openKV("")
+	cc, err := client.NewClientWithDefaults()
 	if err != nil {
 		return err
 	}
-	db.Sync()
-  pn, err := db.Client().DataPath()
-  if err != nil {
-    return err
-  }
-  dbs, err := os.ReadDir(pn + "/kv/")
-  if err != nil {
-    return err
-  }
-  for _, d := range dbs {
-    fmt.Println("@" + d.Name())
-  }
-  return nil
+	dd, err := cc.DataPath()
+	if err != nil {
+		return err
+	}
+	dbs, err := os.ReadDir(filepath.Join(dd, "/kv/"))
+	if err != nil {
+		return err
+	}
+	for _, d := range dbs {
+		fmt.Println("@" + d.Name())
+	}
+	return nil
 }
 
 func list(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This PR resolves #26 by adding a new command `skate list-dbs`. Each database name is prepended with `@` in output for consistency with other commands. 

## Example:
```
~/r/c/skate (feat-list-databases)> ./skate list-dbs
@charm.sh.skate.default
@newdatabase
```
## Pending Questions
- [x] I hacked this together by using an env to get `CHARMPATH=~/.local/share/charm` - how would I get this context? [19fe1b9](https://github.com/charmbracelet/skate/pull/29/commits/19fe1b9b7c70550fce28825e7b2da25b17bdb6c8)
- [x] I'm new to `cobra` so I'm pretty sure there's a better syntax for a command without arguments. Any suggestions? [6d3f172](https://github.com/charmbracelet/skate/pull/29/commits/6d3f172bd98a545fb7782b3701e94fda88a76d95)

## Documentation
Command has built-in documentation, and README has been updated with the new command.

## Further enhancements
- Should `list-dbs` support `--reverse`?
- Accept arguments via stdin?
