### PR TITLE
feat: add option for stylized output

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func get(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(valueStyle.Render(string(v)))
+	fmt.Println(string(v))
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -21,11 +21,10 @@ import (
 
 // styles.
 var (
-	highlight = lipgloss.AdaptiveColor{Light: "#874BFD", Dark: "#7D56F4"}
-	keyStyle  = lipgloss.NewStyle().
+	fuchsia  = lipgloss.AdaptiveColor{Light: "#EE6FF8", Dark: "#EE6FF8"}
+	keyStyle = lipgloss.NewStyle().
 			Align(lipgloss.Left).
-			Foreground(lipgloss.Color("#FAFAFA")).
-			Background(highlight).
+			Foreground(fuchsia).
 			Margin(1, 1, 0, 0).
 			Padding(0, 1)
 	valueStyle = lipgloss.NewStyle().


### PR DESCRIPTION
## Changes
- [x] add styling to skate output `get`, `list`, etc with `-p` flag
- [x] keep option for no styling (default)

## Related Issues
https://github.com/charmbracelet/skate/issues/35

## Note
Formatted output does not support custom delimiters

<img width="1244" alt="dark-mode-preview" src="https://user-images.githubusercontent.com/15822994/167221955-ed68cd67-e474-48f4-9572-5710d7fe820d.png">
 