### PR TITLE
Added mention of CHARM_HOST env variable for self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ local network. For details, see the [Charm docs][selfhost].
 [selfhost]: https://github.com/charmbracelet/charm#self-hosting
 
 If you've finished setting up your very own Charm Cloud, great.
-To make skate connect to your self-hosted instance, you'll need to change the `CHARM_HOST` environment variable to point to the domain/IP of where you hosted your Charm Cloud.
+To make `skate` connect to your self-hosted instance, you'll need to change the `CHARM_HOST` environment variable to point to the domain/IP of where you hosted your Charm Cloud.
 
 ## Hey, Developers
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ local network. For details, see the [Charm docs][selfhost].
 
 [selfhost]: https://github.com/charmbracelet/charm#self-hosting
 
+If you've finished setting up your very own Charm Cloud, great.
+To make skate connect to your self-hosted instance, you'll need to change the `CHARM_HOST` environment variable to point to the domain/IP of where you hosted your Charm Cloud.
+
 ## Hey, Developers
 
 Skate is built on [charm/kv](https://github.com/charmbracelet/charm#charm-kv). If


### PR DESCRIPTION
I added a small mention of the `CHARM_HOST` environment variable to the README under the self-hosting section.
This should make it easier for people to understand how to set up their self-hosted instance of Charm Cloud and Skate :)

thanks for maintaining such a great and useful project 🥇 