### PR TITLE
feat: add suggestions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/charmbracelet/skate
 go 1.17
 
 require (
+	github.com/agnivade/levenshtein v1.1.1
 	github.com/charmbracelet/charm v0.12.4
+	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/roff v0.1.0
@@ -23,7 +25,6 @@ require (
 	github.com/charmbracelet/bubbles v0.13.0 // indirect
 	github.com/charmbracelet/bubbletea v0.23.2 // indirect
 	github.com/charmbracelet/keygen v0.3.0 // indirect
-	github.com/charmbracelet/lipgloss v0.5.0 // indirect
 	github.com/charmbracelet/wish v0.5.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
@@ -76,7 +77,6 @@ require (
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/tools v0.1.12 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	lukechampine.com/uint128 v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
+github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -47,6 +49,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
@@ -75,7 +79,6 @@ github.com/charmbracelet/bubbles v0.13.0 h1:zP/ROH3wJEBqZWKIsD50ZKKlx3ydLInq3LdD
 github.com/charmbracelet/bubbles v0.13.0/go.mod h1:bbeTiXwPww4M031aGi8UK2HT9RDWoiNibae+1yCMtcc=
 github.com/charmbracelet/bubbletea v0.20.0/go.mod h1:zpkze1Rioo4rJELjRyGlm9T2YNou1Fm4LIJQSa5QMEM=
 github.com/charmbracelet/bubbletea v0.21.0/go.mod h1:GgmJMec61d08zXsOhqRC/AiOx4K4pmz+VIcRIm1FKr4=
-github.com/charmbracelet/bubbletea v0.22.0 h1:E1BTNSE3iIrq0G0X6TjGAmrQ32cGCbFDPcIuImikrUc=
 github.com/charmbracelet/bubbletea v0.22.0/go.mod h1:aoVIwlNlr5wbCB26KhxfrqAn0bMp4YpJcoOelbxApjs=
 github.com/charmbracelet/bubbletea v0.23.2 h1:vuUJ9HJ7b/COy4I30e8xDVQ+VRDUEFykIjryPfgsdps=
 github.com/charmbracelet/bubbletea v0.23.2/go.mod h1:FaP3WUivcTM0xOKNmhciz60M6I+weYLF76mr1JyI7sM=
@@ -114,6 +117,8 @@ github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWa
 github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
@@ -266,7 +271,6 @@ github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwM
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -274,7 +278,6 @@ github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2J
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -295,7 +298,6 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b h1:1XF24mVaiu7u+CFywTdcDo2ie1pzzhwjt6RHqzpMU34=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
 github.com/muesli/cancelreader v0.2.0/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
-github.com/muesli/cancelreader v0.2.1 h1:Xzd1B4U5bWQOuSKuN398MyynIGTNT89dxzpEDsalXZs=
 github.com/muesli/cancelreader v0.2.1/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
@@ -317,7 +319,6 @@ github.com/muesli/sasquatch v0.0.0-20200811221207-66979d92330a/go.mod h1:+XG0ne5
 github.com/muesli/termenv v0.8.1/go.mod h1:kzt/D/4a88RoheZmwfqorY3A+tnsSMA9HJC/fQSFKo0=
 github.com/muesli/termenv v0.9.0/go.mod h1:R/LzAKf+suGs4IsO95y7+7DpFHO0KABgnZqtlyx2mBw=
 github.com/muesli/termenv v0.11.1-0.20220204035834-5ac8409525e0/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
-github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739 h1:QANkGiGr39l1EESqrE0gZw0/AJNYzIvoGLhIoVYtluI=
 github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/muesli/termenv v0.14.0 h1:8x9NFfOe8lmIWK4pgy3IfVEy47f+ppe3tUqdPZG2Uy0=
 github.com/muesli/termenv v0.14.0/go.mod h1:kG/pF1E7fh949Xhe156crRUrHNyK221IuGO7Ez60Uc8=
@@ -403,6 +404,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -424,8 +426,8 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd h1:XcWmESyNjXJMLahc3mqVQJcgSTDxFxhETVlfk9uGc38=
 golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
@@ -458,8 +460,8 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -495,8 +497,9 @@ golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5o
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -517,8 +520,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -573,14 +576,13 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
@@ -639,13 +641,12 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201124115921-2c860bdd6e78/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/main.go
+++ b/main.go
@@ -226,8 +226,9 @@ func deleteDb(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	path, err := findDb(args[0], dbs)
-	if errors.Is(err, suggestionNotFoundErr{}) {
-		fmt.Printf("%q does not exist, %s", args[0], err.Error())
+	var notFoundErr suggestionNotFoundErr
+	if errors.As(err, &notFoundErr) {
+		fmt.Printf("%q does not exist, %s\n", args[0], err.Error())
 		os.Exit(1)
 	}
 	var confirmation string

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,9 +21,6 @@ import (
 	"github.com/muesli/roff"
 	"github.com/spf13/cobra"
 )
-
-// distance: an arbitrary number to dictate suggestions.
-const distance = 3
 
 var (
 	Version   = ""
@@ -263,11 +261,10 @@ func findDb(name string, dbs []string) (string, error) {
 		}
 		var suggestions []string
 		for _, db := range dbs {
+			diff := int(math.Abs(float64(len(db) - len(name))))
 			levenshteinDistance := levenshtein.ComputeDistance(name, db)
-			suggestByLevenshtein := levenshteinDistance <= distance
-			suggestByPrefix := strings.HasPrefix(name, db[:distance])
-			suggestByPrefixAlt := strings.HasPrefix("@"+name, db[:distance])
-			if suggestByLevenshtein || suggestByPrefix || suggestByPrefixAlt {
+			suggestByLevenshtein := levenshteinDistance <= diff
+			if suggestByLevenshtein {
 				suggestions = append(suggestions, db)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -244,7 +244,8 @@ func deleteDb(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// findDb: returns the path to the named db, if found.
+// findDb: returns the path to the named db or an errDBNotFound if no
+// match is found.
 func findDb(name string, dbs []string) (string, error) {
 	sName, err := nameFromArgs([]string{name})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -124,15 +124,15 @@ var (
 	}
 )
 
-type suggestionNotFoundErr struct {
+type errDBNotFound struct {
 	suggestions []string
 }
 
-func (e suggestionNotFoundErr) Error() string {
-	if len(e.suggestions) == 0 {
+func (err errDBNotFound) Error() string {
+	if len(err.suggestions) == 0 {
 		return "no suggestions found"
 	}
-	return fmt.Sprintf("did you mean %q", strings.Join(e.suggestions, ", "))
+	return fmt.Sprintf("did you mean %q", strings.Join(err.suggestions, ", "))
 }
 
 func set(cmd *cobra.Command, args []string) error {
@@ -226,14 +226,14 @@ func deleteDb(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	path, err := findDb(args[0], dbs)
-	var notFoundErr suggestionNotFoundErr
-	if errors.As(err, &notFoundErr) {
+	var errNotFound errDBNotFound
+	if errors.As(err, &errNotFound) {
 		fmt.Printf("%q does not exist, %s\n", args[0], err.Error())
 		os.Exit(1)
 	}
 	if err != nil {
-	  fmt.Printf("unexpected error: %s", err.Error())
-	  os.Exit(1)
+		fmt.Printf("unexpected error: %s", err.Error())
+		os.Exit(1)
 	}
 	var confirmation string
 	fmt.Printf("are you sure you want to delete '%s' and all its contents?(y/n) ", warningStyle.Render(path))
@@ -271,7 +271,7 @@ func findDb(name string, dbs []string) (string, error) {
 				suggestions = append(suggestions, db)
 			}
 		}
-		return "", suggestionNotFoundErr{suggestions: suggestions}
+		return "", errDBNotFound{suggestions: suggestions}
 	}
 	return path, nil
 }

--- a/main.go
+++ b/main.go
@@ -252,7 +252,7 @@ func findDb(name string, dbs []string) (string, error) {
 		return "", err
 	}
 	_, err = os.Stat(path)
-	if os.IsNotExist(err) {
+	if sName == "" || os.IsNotExist(err) {
 		dbs, err := getDbs()
 		if err != nil {
 			return "", err
@@ -262,7 +262,8 @@ func findDb(name string, dbs []string) (string, error) {
 			levenshteinDistance := levenshtein.ComputeDistance(name, db)
 			suggestByLevenshtein := levenshteinDistance <= distance
 			suggestByPrefix := strings.HasPrefix(name, db[:distance])
-			if suggestByLevenshtein || suggestByPrefix {
+			suggestByPrefixAlt := strings.HasPrefix("@"+name, db[:distance])
+			if suggestByLevenshtein || suggestByPrefix || suggestByPrefixAlt {
 				suggestions = append(suggestions, db)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -194,13 +194,21 @@ func getDbs() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	var out []string
+	var dbList []string
 	for _, e := range entries {
 		if e.IsDir() {
-			out = append(out, "@"+e.Name())
+			dbList = append(dbList, e.Name())
 		}
 	}
-	return out, nil
+	return formatDbs(dbList), nil
+}
+
+func formatDbs(dbs []string) []string {
+	var out []string
+	for _, db := range dbs {
+		out = append(out, "@"+db)
+	}
+	return out
 }
 
 // getFilePath: get the file path to the skate databases.

--- a/main.go
+++ b/main.go
@@ -231,6 +231,10 @@ func deleteDb(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%q does not exist, %s\n", args[0], err.Error())
 		os.Exit(1)
 	}
+	if err != nil {
+	  fmt.Printf("unexpected error: %s", err.Error())
+	  os.Exit(1)
+	}
 	var confirmation string
 	fmt.Printf("are you sure you want to delete '%s' and all its contents?(y/n) ", warningStyle.Render(path))
 	fmt.Scanln(&confirmation)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// distance: an arbitrary number to dictate suggestions
+// distance: an arbitrary number to dictate suggestions.
 const distance = 3
 
 var (
@@ -34,8 +34,7 @@ var (
 	showBinary       bool
 	delimiterIterate string
 
-	warningStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FD5B5B")).Italic(true)
-	highlightStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5FD2"))
+	warningStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FD5B5B")).Italic(true)
 
 	rootCmd = &cobra.Command{
 		Use:   "skate",
@@ -187,7 +186,7 @@ func listDbs(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-// getDbs: returns a formatted list of available Skate DBs
+// getDbs: returns a formatted list of available Skate DBs.
 func getDbs() ([]string, error) {
 	filepath, err := getFilePath()
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"testing"
 )
 
 func TestFindDbs(t *testing.T) {
 	defaultDbs := []string{
-		"@spongebob",
-		"@charm.sh.kv.user.default",
-		"@charm.sh.skate.default",
+		"spongebob",
+		"charm.sh.kv.user.default",
+		"charm.sh.skate.default",
 	}
 	tests := []struct {
 		name string
@@ -71,24 +73,54 @@ func TestFindDbs(t *testing.T) {
 			err:  nil,
 		},
 	}
-
 	for _, tc := range tests {
-		_, err := findDb(tc.name, tc.dbs)
-		if tc.err != nil {
-			if err == nil {
-				t.Fatalf("expected an error, got: %v", err)
+		t.Run(tc.name, func(t *testing.T) {
+			path := setup(t, tc.dbs)
+			defer teardown(path)
+			_, err := findDb(tc.name, tc.dbs)
+			if tc.err != nil {
+				if err == nil {
+					t.Fatalf("expected an error, got: %v", err)
+				}
+				var perr errDBNotFound
+				if !errors.As(err, &perr) {
+					t.Fatalf("something went wrong! got: %v", err)
+				}
+				if len(err.(errDBNotFound).suggestions) !=
+					len(tc.err.(errDBNotFound).suggestions) {
+
+					t.Fatalf("got != want. got: %v, want: %v", err, tc.err)
+				}
 			}
-			var perr errDBNotFound
-			if !errors.As(err, &perr) {
-				t.Fatalf("something went wrong! got: %v", err)
+			if err != nil && tc.err == nil {
+				t.Fatalf("got an unexpected error: %v", err)
 			}
-			if len(err.(errDBNotFound).suggestions) !=
-				len(tc.err.(errDBNotFound).suggestions) {
-				t.Fatalf("got != want. got: %v, want: %v", err, tc.err)
+			if err := teardown(path); err != nil {
+				t.Fatal(err)
 			}
+		})
+	}
+}
+
+// TODO: use local charm server for testing instead of pinging cloud services
+func setup(t *testing.T, dbs []string) string {
+	// set up charm kv temp path for tests
+	dir := os.TempDir()
+	path := fmt.Sprintf("%scharm-tests", dir)
+	t.Setenv("CHARM_DATA_DIR", path)
+	// create the kv dbs
+	for _, db := range dbs {
+		charmKV, err := openKV(db)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if err != nil && tc.err == nil {
-			t.Fatalf("got an unexpected error: %v", err)
+		if err := charmKV.Close(); err != nil {
+			t.Fatal(err)
 		}
 	}
+	return path
+}
+
+func teardown(path string) error {
+	return os.RemoveAll(path)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 	"os"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/charmbracelet/charm/testserver"
@@ -33,7 +35,7 @@ func TestFindDbs(t *testing.T) {
 		},
 		{
 			tname: "name > db",
-			name:  "pcharm.sh.kv.user.defaultcharm.sh.kv.user.default",
+			name:  "pcharm.sh.kv.user.defaultii",
 			dbs:   defaultDbs,
 			err: errDBNotFound{
 				suggestions: nil,
@@ -45,7 +47,7 @@ func TestFindDbs(t *testing.T) {
 			name:  "",
 			dbs:   defaultDbs,
 			err: errDBNotFound{
-				suggestions: defaultDbs,
+				suggestions: formatDbs(defaultDbs),
 			},
 		},
 		{
@@ -111,12 +113,17 @@ func TestFindDbs(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected an error, got: %v", err)
 				}
+				// check we got the right type of error
 				var perr errDBNotFound
 				if !errors.As(err, &perr) {
 					t.Fatalf("something went wrong! got: %v", err)
 				}
-				if len(err.(errDBNotFound).suggestions) !=
-					len(tc.err.(errDBNotFound).suggestions) {
+				// check suggestions match
+				gotSuggestions := err.(errDBNotFound).suggestions
+				wantSuggestions := tc.err.(errDBNotFound).suggestions
+				sort.Strings(gotSuggestions)
+				sort.Strings(wantSuggestions)
+				if !reflect.DeepEqual(gotSuggestions, wantSuggestions) {
 					t.Fatalf("got != want. got: %v, want: %v", err, tc.err)
 				}
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -75,8 +75,12 @@ func TestFindDbs(t *testing.T) {
 	for _, tc := range tests {
 		_, err := findDb(tc.name, tc.dbs)
 		if tc.err != nil {
-			if err == nil || errors.Is(err, suggestionNotFoundErr{}) {
+			if err == nil {
 				t.Fatalf("expected an error, got: %v", err)
+			}
+			var perr suggestionNotFoundErr
+			if !errors.As(err, &perr) {
+				t.Fatalf("something went wrong! got: %v", err)
 			}
 			if len(err.(suggestionNotFoundErr).suggestions) !=
 				len(tc.err.(suggestionNotFoundErr).suggestions) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFindDbs(t *testing.T) {
+	defaultDbs := []string{
+		"@spongebob",
+		"@charm.sh.kv.user.default",
+		"@charm.sh.skate.default",
+	}
+	tests := []struct {
+		name string
+		dbs  []string
+		err  error
+	}{
+		{
+			name: "@spon",
+			dbs:  defaultDbs,
+			err: dbNotFoundErr{
+				name: "@spon",
+				suggestions: []string{
+					"@spongebob",
+				},
+				isEmpty: false,
+			},
+		},
+		{
+			name: "spon",
+			dbs:  defaultDbs,
+			err: dbNotFoundErr{
+				name:        "spon",
+				suggestions: defaultDbs,
+				isEmpty:     false,
+			},
+		},
+		{
+			name: "",
+			dbs:  defaultDbs,
+			err: dbNotFoundErr{
+				name:        "spon",
+				suggestions: defaultDbs,
+				isEmpty:     true,
+			},
+		},
+		{
+			name: "endo",
+			dbs:  defaultDbs,
+			err: dbNotFoundErr{
+				name:        "spon",
+				suggestions: defaultDbs,
+				isEmpty:     true,
+			},
+		},
+		{
+			name: "@endo",
+			dbs:  defaultDbs,
+			err: dbNotFoundErr{
+				name:        "spon",
+				suggestions: defaultDbs,
+				isEmpty:     true,
+			},
+		},
+		{
+			name: "@spongebob",
+			dbs:  defaultDbs,
+			err:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		_, err := findDb(tc.name, tc.dbs)
+		if tc.err != nil {
+			if err == nil || errors.Is(err, dbNotFoundErr{}) {
+				t.Fatalf("expected an error, got: %v", err)
+			}
+			gIsEmpty := err.(dbNotFoundErr).isEmpty
+			wIsEmpty := tc.err.(dbNotFoundErr).isEmpty
+			if gIsEmpty != wIsEmpty {
+				t.Fatalf("got: %t, want: %t", gIsEmpty, wIsEmpty)
+			}
+		}
+		if err != nil && tc.err == nil {
+			t.Fatalf("got an unexpected error: %v", err)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"testing"
+
+	"github.com/charmbracelet/charm/testserver"
 )
 
 func TestFindDbs(t *testing.T) {
@@ -95,20 +96,14 @@ func TestFindDbs(t *testing.T) {
 			if err != nil && tc.err == nil {
 				t.Fatalf("got an unexpected error: %v", err)
 			}
-			if err := teardown(path); err != nil {
-				t.Fatal(err)
-			}
 		})
 	}
 }
 
-// TODO: use local charm server for testing instead of pinging cloud services
 func setup(t *testing.T, dbs []string) string {
-	// set up charm kv temp path for tests
-	dir := os.TempDir()
-	path := fmt.Sprintf("%scharm-tests", dir)
-	t.Setenv("CHARM_DATA_DIR", path)
-	// create the kv dbs
+	// set up a charm server for testing
+	client := testserver.SetupTestServer(t)
+	// add the skate dbs
 	for _, db := range dbs {
 		charmKV, err := openKV(db)
 		if err != nil {
@@ -117,6 +112,10 @@ func setup(t *testing.T, dbs []string) string {
 		if err := charmKV.Close(); err != nil {
 			t.Fatal(err)
 		}
+	}
+	path, err := client.DataPath()
+	if err != nil {
+		t.Fatal(err)
 	}
 	return path
 }

--- a/main_test.go
+++ b/main_test.go
@@ -89,7 +89,6 @@ func TestFindDbs(t *testing.T) {
 				}
 				if len(err.(errDBNotFound).suggestions) !=
 					len(tc.err.(errDBNotFound).suggestions) {
-
 					t.Fatalf("got != want. got: %v, want: %v", err, tc.err)
 				}
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -19,7 +19,7 @@ func TestFindDbs(t *testing.T) {
 		{
 			name: "@spon",
 			dbs:  defaultDbs,
-			err: suggestionNotFoundErr{
+			err: errDBNotFound{
 				suggestions: []string{
 					"@spongebob",
 				},
@@ -28,7 +28,7 @@ func TestFindDbs(t *testing.T) {
 		{
 			name: "@char",
 			dbs:  defaultDbs,
-			err: suggestionNotFoundErr{
+			err: errDBNotFound{
 				suggestions: []string{
 					"@charm.sh.kv.user.default",
 					"@charm.sh.skate.default",
@@ -38,7 +38,7 @@ func TestFindDbs(t *testing.T) {
 		{
 			name: "spon",
 			dbs:  defaultDbs,
-			err: suggestionNotFoundErr{
+			err: errDBNotFound{
 				suggestions: []string{
 					"@spongebob",
 				},
@@ -47,21 +47,21 @@ func TestFindDbs(t *testing.T) {
 		{
 			name: "",
 			dbs:  defaultDbs,
-			err: suggestionNotFoundErr{
+			err: errDBNotFound{
 				suggestions: nil,
 			},
 		},
 		{
 			name: "endo",
 			dbs:  defaultDbs,
-			err: suggestionNotFoundErr{
+			err: errDBNotFound{
 				suggestions: nil,
 			},
 		},
 		{
 			name: "@endo",
 			dbs:  defaultDbs,
-			err: suggestionNotFoundErr{
+			err: errDBNotFound{
 				suggestions: nil,
 			},
 		},
@@ -78,12 +78,12 @@ func TestFindDbs(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected an error, got: %v", err)
 			}
-			var perr suggestionNotFoundErr
+			var perr errDBNotFound
 			if !errors.As(err, &perr) {
 				t.Fatalf("something went wrong! got: %v", err)
 			}
-			if len(err.(suggestionNotFoundErr).suggestions) !=
-				len(tc.err.(suggestionNotFoundErr).suggestions) {
+			if len(err.(errDBNotFound).suggestions) !=
+				len(tc.err.(errDBNotFound).suggestions) {
 				t.Fatalf("got != want. got: %v, want: %v", err, tc.err)
 			}
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -13,15 +13,18 @@ func TestFindDbs(t *testing.T) {
 		"spongebob",
 		"charm.sh.kv.user.default",
 		"charm.sh.skate.default",
+		"sk",
 	}
 	tests := []struct {
-		name string
-		dbs  []string
-		err  error
+		tname string
+		name  string
+		dbs   []string
+		err   error
 	}{
 		{
-			name: "@spon",
-			dbs:  defaultDbs,
+			tname: "unique, single char",
+			name:  "p",
+			dbs:   defaultDbs,
 			err: errDBNotFound{
 				suggestions: []string{
 					"@spongebob",
@@ -29,8 +32,36 @@ func TestFindDbs(t *testing.T) {
 			},
 		},
 		{
-			name: "@char",
-			dbs:  defaultDbs,
+			tname: "name > db",
+			name:  "pcharm.sh.kv.user.defaultcharm.sh.kv.user.default",
+			dbs:   defaultDbs,
+			err: errDBNotFound{
+				suggestions: nil,
+			},
+		},
+
+		{
+			tname: "empty",
+			name:  "",
+			dbs:   defaultDbs,
+			err: errDBNotFound{
+				suggestions: defaultDbs,
+			},
+		},
+		{
+			tname: "single match",
+			name:  "@spon",
+			dbs:   defaultDbs,
+			err: errDBNotFound{
+				suggestions: []string{
+					"@spongebob",
+				},
+			},
+		},
+		{
+			tname: "charm match",
+			name:  "@char",
+			dbs:   defaultDbs,
 			err: errDBNotFound{
 				suggestions: []string{
 					"@charm.sh.kv.user.default",
@@ -39,8 +70,9 @@ func TestFindDbs(t *testing.T) {
 			},
 		},
 		{
-			name: "spon",
-			dbs:  defaultDbs,
+			tname: "single match, no @",
+			name:  "spon",
+			dbs:   defaultDbs,
 			err: errDBNotFound{
 				suggestions: []string{
 					"@spongebob",
@@ -48,34 +80,30 @@ func TestFindDbs(t *testing.T) {
 			},
 		},
 		{
-			name: "",
-			dbs:  defaultDbs,
+			tname: "no match, no @",
+			name:  "endo",
+			dbs:   defaultDbs,
 			err: errDBNotFound{
 				suggestions: nil,
 			},
 		},
 		{
-			name: "endo",
-			dbs:  defaultDbs,
+			tname: "no match",
+			name:  "@endo",
+			dbs:   defaultDbs,
 			err: errDBNotFound{
 				suggestions: nil,
 			},
 		},
 		{
-			name: "@endo",
-			dbs:  defaultDbs,
-			err: errDBNotFound{
-				suggestions: nil,
-			},
-		},
-		{
-			name: "@spongebob",
-			dbs:  defaultDbs,
-			err:  nil,
+			tname: "exact match",
+			name:  "@spongebob",
+			dbs:   defaultDbs,
+			err:   nil,
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.tname, func(t *testing.T) {
 			path := setup(t, tc.dbs)
 			defer teardown(path)
 			_, err := findDb(tc.name, tc.dbs)

--- a/main_test.go
+++ b/main_test.go
@@ -19,48 +19,50 @@ func TestFindDbs(t *testing.T) {
 		{
 			name: "@spon",
 			dbs:  defaultDbs,
-			err: dbNotFoundErr{
-				name: "@spon",
+			err: suggestionNotFoundErr{
 				suggestions: []string{
 					"@spongebob",
 				},
-				isEmpty: false,
+			},
+		},
+		{
+			name: "@char",
+			dbs:  defaultDbs,
+			err: suggestionNotFoundErr{
+				suggestions: []string{
+					"@charm.sh.kv.user.default",
+					"@charm.sh.skate.default",
+				},
 			},
 		},
 		{
 			name: "spon",
 			dbs:  defaultDbs,
-			err: dbNotFoundErr{
-				name:        "spon",
-				suggestions: defaultDbs,
-				isEmpty:     false,
+			err: suggestionNotFoundErr{
+				suggestions: []string{
+					"@spongebob",
+				},
 			},
 		},
 		{
 			name: "",
 			dbs:  defaultDbs,
-			err: dbNotFoundErr{
-				name:        "spon",
-				suggestions: defaultDbs,
-				isEmpty:     true,
+			err: suggestionNotFoundErr{
+				suggestions: nil,
 			},
 		},
 		{
 			name: "endo",
 			dbs:  defaultDbs,
-			err: dbNotFoundErr{
-				name:        "spon",
-				suggestions: defaultDbs,
-				isEmpty:     true,
+			err: suggestionNotFoundErr{
+				suggestions: nil,
 			},
 		},
 		{
 			name: "@endo",
 			dbs:  defaultDbs,
-			err: dbNotFoundErr{
-				name:        "spon",
-				suggestions: defaultDbs,
-				isEmpty:     true,
+			err: suggestionNotFoundErr{
+				suggestions: nil,
 			},
 		},
 		{
@@ -73,13 +75,12 @@ func TestFindDbs(t *testing.T) {
 	for _, tc := range tests {
 		_, err := findDb(tc.name, tc.dbs)
 		if tc.err != nil {
-			if err == nil || errors.Is(err, dbNotFoundErr{}) {
+			if err == nil || errors.Is(err, suggestionNotFoundErr{}) {
 				t.Fatalf("expected an error, got: %v", err)
 			}
-			gIsEmpty := err.(dbNotFoundErr).isEmpty
-			wIsEmpty := tc.err.(dbNotFoundErr).isEmpty
-			if gIsEmpty != wIsEmpty {
-				t.Fatalf("got: %t, want: %t", gIsEmpty, wIsEmpty)
+			if len(err.(suggestionNotFoundErr).suggestions) !=
+				len(tc.err.(suggestionNotFoundErr).suggestions) {
+				t.Fatalf("got != want. got: %v, want: %v", err, tc.err)
 			}
 		}
 		if err != nil && tc.err == nil {


### PR DESCRIPTION
builds off of the `delete-db` PR. Suggests a db name that does exist based on the first two characters of a mistyped arg. Just kept it simple, but would be great to hear if there are better ways to do this. I also experimented with having a more reusable function for getting the `[]os.DirEntry` for a default client. 

Would also love some guidance on how I could write tests for this 💭 