### PR TITLE
Document the fact that `set` works with STDIN if the value is omitted

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,8 +44,8 @@ var (
 	}
 
 	setCmd = &cobra.Command{
-		Use:   "set KEY[@DB] VALUE",
-		Short: "Set a value for a key with an optional @ db.",
+		Use:   "set KEY[@DB] [VALUE]",
+		Short: "Set a value for a key with an optional @ db. If VALUE is omitted, read value from the standard input.",
 		Args:  cobra.RangeArgs(1, 2),
 		RunE:  set,
 	}


### PR DESCRIPTION
I was about to suggest implementing this feature when I found it's already implemented, just not documented.