### PR TITLE
feat!: rename module to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/charmbracelet/skate
+module github.com/charmbracelet/skate/v2
 
 go 1.21
 


### PR DESCRIPTION
Next version of skate drops the cloud features, which is a breaking change.

This makes it so.