### PR TITLE
feat(list): show single-line previews for long/multiline values

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	keysIterate      bool
 	valuesIterate    bool
 	showBinary       bool
+	noTruncate       bool
 	delimiterIterate string
 
 	warningStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("204")).Bold(true)
@@ -339,10 +340,14 @@ func list(_ *cobra.Command, args []string) error {
 				continue
 			}
 			err := item.Value(func(v []byte) error {
+				preview := v
+				if !noTruncate {
+					preview = previewValue(v)
+				}
 				if valuesIterate {
-					printFromKV(pf, v)
+					printFromKV(pf, preview)
 				} else {
-					printFromKV(pf, k, v)
+					printFromKV(pf, k, preview)
 				}
 				return nil
 			})
@@ -352,6 +357,35 @@ func list(_ *cobra.Command, args []string) error {
 		}
 		return nil
 	})
+}
+
+// previewLen is the maximum length of a value preview shown by skate list.
+const previewLen = 80
+
+// previewValue returns a single-line preview of v suitable for skate list
+// output. Newlines are escaped to "\n" and values longer than previewLen are
+// truncated with a "(N more chars)" suffix so the listing stays scannable when
+// values are large or multiline. Non-UTF-8 values are returned unchanged so
+// the existing binary handling in printFromKV still applies.
+func previewValue(v []byte) []byte {
+	if !utf8.Valid(v) {
+		return v
+	}
+	s := string(v)
+	hasNewline := strings.ContainsAny(s, "\n\r")
+	if !hasNewline && len(s) <= previewLen {
+		return v
+	}
+	full := len(s)
+	if len(s) > previewLen {
+		s = s[:previewLen]
+	}
+	r := strings.NewReplacer("\n", `\n`, "\r", `\r`)
+	s = r.Replace(s)
+	if full > previewLen {
+		s = fmt.Sprintf("%s  (%d more chars)", s, full-previewLen)
+	}
+	return []byte(s)
 }
 
 func nameFromArgs(args []string) (string, error) {
@@ -414,6 +448,7 @@ func init() {
 	listCmd.Flags().BoolVarP(&valuesIterate, "values-only", "v", false, "only print values")
 	listCmd.Flags().StringVarP(&delimiterIterate, "delimiter", "d", "\t", "delimiter to separate keys and values")
 	listCmd.Flags().BoolVarP(&showBinary, "show-binary", "b", false, "print binary values")
+	listCmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "print full values instead of single-line previews")
 	getCmd.Flags().BoolVarP(&showBinary, "show-binary", "b", false, "print binary values")
 
 	rootCmd.AddCommand(

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPreviewValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "short single line is unchanged",
+			in:   "hello world",
+			want: "hello world",
+		},
+		{
+			name: "multiline short value escapes newlines",
+			in:   "line1\nline2\nline3",
+			want: `line1\nline2\nline3`,
+		},
+		{
+			name: "carriage return is escaped too",
+			in:   "a\r\nb",
+			want: `a\r\nb`,
+		},
+		{
+			name: "long single line is truncated with suffix",
+			in:   strings.Repeat("a", previewLen+10),
+			want: strings.Repeat("a", previewLen) + "  (10 more chars)",
+		},
+		{
+			name: "long multiline value is truncated and escaped",
+			in:   "#!/bin/sh\n" + strings.Repeat("x", previewLen),
+			// The first previewLen chars are "#!/bin/sh\n" + 70 "x"s, which after
+			// escaping the newline becomes "#!/bin/sh\\n" + 70 "x"s.
+			want: `#!/bin/sh\n` + strings.Repeat("x", previewLen-len("#!/bin/sh\n")) + "  (10 more chars)",
+		},
+		{
+			name: "exactly previewLen single-line value is not truncated",
+			in:   strings.Repeat("a", previewLen),
+			want: strings.Repeat("a", previewLen),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(previewValue([]byte(tt.in)))
+			if got != tt.want {
+				t.Errorf("previewValue() got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreviewValue_BinaryIsUnchanged(t *testing.T) {
+	// Non-UTF-8 input: the binary detection in printFromKV is what masks
+	// these, previewValue should leave them alone so that path keeps working.
+	binary := []byte{0xff, 0xfe, 0xfd, 0x00, 0x01}
+	got := previewValue(binary)
+	if string(got) != string(binary) {
+		t.Errorf("previewValue mangled binary input: %v -> %v", binary, got)
+	}
+}


### PR DESCRIPTION
Closes #97.

\`skate list\` used to dump the full value of every key, so storing a shell script (or anything multi-line) made the listing unusable, the script splatted across many lines and any following keys got mixed in.

Now \`list\` prints a single-line preview per value:

- newlines and carriage returns are escaped to \`\\n\` / \`\\r\`
- values longer than 80 chars get truncated with a \`(N more chars)\` suffix

\`skate get\` is unchanged so the full value is still one command away. Added \`--no-truncate\` for anyone who actually wants the old list output (scripts piping the output, etc.). Keys-only mode and binary handling are unchanged.

The example from the issue looks roughly like:

\`\`\`
script  #!/bin/sh\\n#script comment\\n  (2000 more chars)
\`\`\`

## Test plan

\`\`\`
go test ./...
\`\`\`

Added \`TestPreviewValue\` covering short, multiline-short, long, long-multiline, exactly-at-limit, and binary inputs.